### PR TITLE
Issue #52 - Edit defendant on the asset form

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "ng": "ng",
     "preinstall": "npm install -g @angular/cli",
     "start": "ng serve --host localhost --port 5000",
-    "start:fake": "ng serve --env fake --host localhost --port 5000",
-    "start:local": "ng serve --env local --host localhost --port 5000",
+    "start:fake": "ng serve --configuration=fake --host localhost --port 5000",
+    "start:local": "ng serve --configuration=local --host localhost --port 5000",
     "test": "ng test --watch=false --code-coverage",
     "test:watch": "ng test --code-coverage"
   },

--- a/src/app/assets/components/edit-defendant/edit-defendant.component.html
+++ b/src/app/assets/components/edit-defendant/edit-defendant.component.html
@@ -3,7 +3,7 @@
 
   <form [formGroup]="defendantForm" (ngSubmit)="save()">
     <mat-form-field>
-      <mat-select placeholder="Tip inculpat" 
+      <mat-select placeholder="Tip inculpat"
                   formControlName="defendantType"
       >
         <mat-option *ngFor="let option of defendantTypeOptions" [value]="option">
@@ -97,8 +97,8 @@
     </div>
 
     <div class="row actions">
-      <button mat-button (click)="cancel()">ANULEAZA</button>
-      <button mat-raised-button color="primary" type="submit" [disabled]="!isFormValid">SALVEAZA</button>
+      <button mat-button (click)="cancel()">Anuleaza</button>
+      <button mat-raised-button color="primary" type="submit" [disabled]="!isFormValid">Salveaza</button>
     </div>
   </form>
 </section>

--- a/src/app/assets/components/edit-defendant/edit-defendant.component.ts
+++ b/src/app/assets/components/edit-defendant/edit-defendant.component.ts
@@ -84,10 +84,12 @@ export class EditDefendantComponent implements OnInit {
   }
 
   get isFormValid(): boolean {
-    return this.isPerson(this.defendantType) &&
-      this.defendantForm.get('pf').valid ||
-      this.isCompany(this.defendantType) &&
-      this.defendantForm.get('pj').valid
+
+    if (this.isPerson(this.defendantType)) {
+      return this.defendantForm.get('pf').valid;
+    }
+
+    return this.defendantForm.get('pj').valid;
   }
 
   get defendantType(): string {

--- a/src/app/assets/components/view-defendant/view-defendant.component.html
+++ b/src/app/assets/components/view-defendant/view-defendant.component.html
@@ -45,11 +45,16 @@
     </div>
   </div>
   <section class="buttons">
-    <button 
-      mat-raised-button 
-      (click)="onDefendantDeleted()" 
+    <button
+      mat-raised-button
+      (click)="onDefendantDeleted()"
       color="warn"
       [disabled]="isDeleting"
     >Sterge</button>
+    <button
+      mat-raised-button
+      (click)="onDefendantEdit()"
+      color="primary"
+    >Modifica</button>
   </section>
 </section>

--- a/src/app/assets/components/view-defendant/view-defendant.component.scss
+++ b/src/app/assets/components/view-defendant/view-defendant.component.scss
@@ -23,5 +23,9 @@
   .buttons {
     display: flex;
     justify-content: flex-end;
+
+    button {
+      margin-left: .5em;
+    }
   }
 }

--- a/src/app/assets/components/view-defendant/view-defendant.component.ts
+++ b/src/app/assets/components/view-defendant/view-defendant.component.ts
@@ -11,6 +11,7 @@ export class ViewDefendantComponent {
   @Input() identifiers: Identifier[];
   @Input() isDeleting: boolean;
   @Output() defendantDeleted: EventEmitter<Defendant> = new EventEmitter<Defendant>();
+  @Output() defendantEdit: EventEmitter<Defendant> = new EventEmitter<Defendant>();
 
   getDefendantType(aIsPerson: boolean) {
     return aIsPerson ? DefendantType.Person.toString() : DefendantType.Company.toString();
@@ -22,5 +23,9 @@ export class ViewDefendantComponent {
 
   onDefendantDeleted() {
     this.defendantDeleted.emit(this.defendant);
+  }
+
+  onDefendantEdit() {
+    this.defendantEdit.emit(this.defendant);
   }
 }

--- a/src/app/assets/containers/asset-detail/asset-detail.component.html
+++ b/src/app/assets/containers/asset-detail/asset-detail.component.html
@@ -100,49 +100,49 @@
     </div>
 
     <ng-template #editProperty>
-        <app-edit-solution
-          class="asset-details-card mat-elevation-z8"
-          *ngIf="(assetProperty$ | async)?.isSolution()"
-          [crimeTypes]="crimeTypes$ | async"
-          [decisions]="decisions$ | async"
-          [institutions]="institutions$ | async"
-          [stages]="stages$ | async"
-          [precautionaryMeasures]="(precautionaryMeasures$ | async)"
-          [recoveryBeneficiaries]="(recoveryBeneficiaries$ | async)"
-          [solution]="assetProperty$ | async"
-          (onUpdate)="onPropertyUpdate($event)"
-          (onCancel)="onPropertyCancel($event)"
-          (onSave)="onPropertySave($event)"
-        ></app-edit-solution>
+      <app-edit-solution
+        class="asset-details-card mat-elevation-z8"
+        *ngIf="(assetProperty$ | async)?.isSolution()"
+        [crimeTypes]="crimeTypes$ | async"
+        [decisions]="decisions$ | async"
+        [institutions]="institutions$ | async"
+        [stages]="stages$ | async"
+        [precautionaryMeasures]="(precautionaryMeasures$ | async)"
+        [recoveryBeneficiaries]="(recoveryBeneficiaries$ | async)"
+        [solution]="assetProperty$ | async"
+        (onUpdate)="onPropertyUpdate($event)"
+        (onCancel)="onPropertyCancel($event)"
+        (onSave)="onPropertySave($event)"
+      ></app-edit-solution>
 
-        <app-edit-storage
-          class="asset-details-card mat-elevation-z8"
-          *ngIf="(assetProperty$ | async)?.isStorageSpace()"
-          [storageSpace]="assetProperty$ | async"
-          (onUpdate)="onPropertyUpdate($event)"
-          (onCancel)="onPropertyCancel($event)"
-          (onSave)="onPropertySave($event)"
-        ></app-edit-storage>
+      <app-edit-storage
+        class="asset-details-card mat-elevation-z8"
+        *ngIf="(assetProperty$ | async)?.isStorageSpace()"
+        [storageSpace]="assetProperty$ | async"
+        (onUpdate)="onPropertyUpdate($event)"
+        (onCancel)="onPropertyCancel($event)"
+        (onSave)="onPropertySave($event)"
+      ></app-edit-storage>
 
-        <app-edit-address
-          class="asset-details-card mat-elevation-z8"
-          *ngIf="(assetProperty$ | async)?.isAddress()"
-          [address]="(assetProperty$ | async)"
-          [counties]="(counties$ | async)"
-          (onUpdate)="onPropertyUpdate($event)"
-          (onCancel)="onPropertyCancel($event)"
-          (onSave)="onPropertySave($event)"
-        ></app-edit-address>
+      <app-edit-address
+        class="asset-details-card mat-elevation-z8"
+        *ngIf="(assetProperty$ | async)?.isAddress()"
+        [address]="(assetProperty$ | async)"
+        [counties]="(counties$ | async)"
+        (onUpdate)="onPropertyUpdate($event)"
+        (onCancel)="onPropertyCancel($event)"
+        (onSave)="onPropertySave($event)"
+      ></app-edit-address>
 
-        <app-edit-defendant
-          class="asset-details-card mat-elevation-z8"
-          *ngIf="(assetProperty$ | async)?.isDefendant()"
-          [defendant]="(assetProperty$ | async)"
-          [identifiers]="(identifiers$ | async)"
-          (onUpdate)="onPropertyUpdate($event)"
-          (onCancel)="onPropertyCancel($event)"
-          (onSave)="onPropertySave($event)"
-        ></app-edit-defendant>
+      <app-edit-defendant
+        class="asset-details-card mat-elevation-z8"
+        *ngIf="(assetProperty$ | async)?.isDefendant()"
+        [defendant]="(assetProperty$ | async)"
+        [identifiers]="(identifiers$ | async)"
+        (onUpdate)="onPropertyUpdate($event)"
+        (onCancel)="onPropertyCancel($event)"
+        (onSave)="onPropertySave($event)"
+      ></app-edit-defendant>
     </ng-template>
   </section>
 </div>

--- a/src/app/assets/containers/asset-detail/asset-detail.component.html
+++ b/src/app/assets/containers/asset-detail/asset-detail.component.html
@@ -63,7 +63,8 @@
         [identifiers]="identifiers$ | async"
         *ngIf="getPropertyState(theDefendant.id) === 'edit'"
         (onCancel)="setPropertyStateView(theDefendant.id)"
-        (onSave)="onPropertyEdit(theDefendant)"
+        (onUpdate)="onPropertyUpdate($event)"
+        (onSave)="onPropertyEdit($event)"
       > </app-edit-defendant>
     </div>
   </section>

--- a/src/app/assets/containers/asset-detail/asset-detail.component.html
+++ b/src/app/assets/containers/asset-detail/asset-detail.component.html
@@ -52,10 +52,19 @@
     <div class="asset-details-card mat-elevation-z8" *ngFor="let theDefendant of (defendants$ | async)">
       <app-view-defendant
         [defendant]="theDefendant"
+        *ngIf="getPropertyState(theDefendant.id) === 'view'"
         [identifiers]="identifiers$ | async"
         [isDeleting]="(isDefendantDeleting$(theDefendant.id) | async)"
         (defendantDeleted)="onDefendantDeleted($event)"
+        (defendantEdit)="setPropertyStateEdit(theDefendant.id)"
       ></app-view-defendant>
+      <app-edit-defendant
+        [defendant]="theDefendant"
+        [identifiers]="identifiers$ | async"
+        *ngIf="getPropertyState(theDefendant.id) === 'edit'"
+        (onCancel)="setPropertyStateView(theDefendant.id)"
+        (onSave)="onPropertyEdit(theDefendant)"
+      > </app-edit-defendant>
     </div>
   </section>
 
@@ -91,49 +100,49 @@
     </div>
 
     <ng-template #editProperty>
-      <app-edit-solution
-        class="mat-elevation-z8"
-        *ngIf="(assetProperty$ | async)?.isSolution()"
-        [crimeTypes]="crimeTypes$ | async"
-        [decisions]="decisions$ | async"
-        [institutions]="institutions$ | async"
-        [stages]="stages$ | async"
-        [precautionaryMeasures]="(precautionaryMeasures$ | async)"
-        [recoveryBeneficiaries]="(recoveryBeneficiaries$ | async)"
-        [solution]="assetProperty$ | async"
-        (onUpdate)="onPropertyUpdate($event)"
-        (onCancel)="onPropertyCancel($event)"
-        (onSave)="onPropertySave($event)"
-      ></app-edit-solution>
+        <app-edit-solution
+          class="asset-details-card mat-elevation-z8"
+          *ngIf="(assetProperty$ | async)?.isSolution()"
+          [crimeTypes]="crimeTypes$ | async"
+          [decisions]="decisions$ | async"
+          [institutions]="institutions$ | async"
+          [stages]="stages$ | async"
+          [precautionaryMeasures]="(precautionaryMeasures$ | async)"
+          [recoveryBeneficiaries]="(recoveryBeneficiaries$ | async)"
+          [solution]="assetProperty$ | async"
+          (onUpdate)="onPropertyUpdate($event)"
+          (onCancel)="onPropertyCancel($event)"
+          (onSave)="onPropertySave($event)"
+        ></app-edit-solution>
 
-      <app-edit-storage
-        class="mat-elevation-z8"
-        *ngIf="(assetProperty$ | async)?.isStorageSpace()"
-        [storageSpace]="assetProperty$ | async"
-        (onUpdate)="onPropertyUpdate($event)"
-        (onCancel)="onPropertyCancel($event)"
-        (onSave)="onPropertySave($event)"
-      ></app-edit-storage>
+        <app-edit-storage
+          class="asset-details-card mat-elevation-z8"
+          *ngIf="(assetProperty$ | async)?.isStorageSpace()"
+          [storageSpace]="assetProperty$ | async"
+          (onUpdate)="onPropertyUpdate($event)"
+          (onCancel)="onPropertyCancel($event)"
+          (onSave)="onPropertySave($event)"
+        ></app-edit-storage>
 
-      <app-edit-address
-        class="mat-elevation-z8"
-        *ngIf="(assetProperty$ | async)?.isAddress()"
-        [address]="(assetProperty$ | async)"
-        [counties]="(counties$ | async)"
-        (onUpdate)="onPropertyUpdate($event)"
-        (onCancel)="onPropertyCancel($event)"
-        (onSave)="onPropertySave($event)"
-      ></app-edit-address>
+        <app-edit-address
+          class="asset-details-card mat-elevation-z8"
+          *ngIf="(assetProperty$ | async)?.isAddress()"
+          [address]="(assetProperty$ | async)"
+          [counties]="(counties$ | async)"
+          (onUpdate)="onPropertyUpdate($event)"
+          (onCancel)="onPropertyCancel($event)"
+          (onSave)="onPropertySave($event)"
+        ></app-edit-address>
 
-      <app-edit-defendant
-        class="mat-elevation-z8"
-        *ngIf="(assetProperty$ | async)?.isDefendant()"
-        [defendant]="(assetProperty$ | async)"
-        [identifiers]="(identifiers$ | async)"
-        (onUpdate)="onPropertyUpdate($event)"
-        (onCancel)="onPropertyCancel($event)"
-        (onSave)="onPropertySave($event)"
-      ></app-edit-defendant>
+        <app-edit-defendant
+          class="asset-details-card mat-elevation-z8"
+          *ngIf="(assetProperty$ | async)?.isDefendant()"
+          [defendant]="(assetProperty$ | async)"
+          [identifiers]="(identifiers$ | async)"
+          (onUpdate)="onPropertyUpdate($event)"
+          (onCancel)="onPropertyCancel($event)"
+          (onSave)="onPropertySave($event)"
+        ></app-edit-defendant>
     </ng-template>
   </section>
 </div>

--- a/src/app/assets/containers/asset-detail/asset-detail.component.html
+++ b/src/app/assets/containers/asset-detail/asset-detail.component.html
@@ -52,7 +52,7 @@
     <div class="asset-details-card mat-elevation-z8" *ngFor="let theDefendant of (defendants$ | async)">
       <app-view-defendant
         [defendant]="theDefendant"
-        *ngIf="getPropertyState(theDefendant.id) === 'view'"
+        *ngIf="isPropertyStateView(theDefendant.id)"
         [identifiers]="identifiers$ | async"
         [isDeleting]="(isDefendantDeleting$(theDefendant.id) | async)"
         (defendantDeleted)="onDefendantDeleted($event)"
@@ -61,10 +61,10 @@
       <app-edit-defendant
         [defendant]="theDefendant"
         [identifiers]="identifiers$ | async"
-        *ngIf="getPropertyState(theDefendant.id) === 'edit'"
+        *ngIf="isPropertyStateEdit(theDefendant.id)"
         (onCancel)="setPropertyStateView(theDefendant.id)"
         (onUpdate)="onPropertyUpdate($event)"
-        (onSave)="onPropertyEdit($event)"
+        (onSave)="onPropertyPersist($event)"
       > </app-edit-defendant>
     </div>
   </section>

--- a/src/app/assets/containers/asset-detail/asset-detail.component.scss
+++ b/src/app/assets/containers/asset-detail/asset-detail.component.scss
@@ -49,8 +49,4 @@
       justify-content: flex-end;
     }
   }
-
-  app-edit-solution, app-edit-storage, app-edit-address, app-edit-defendant {
-    @include material-card();
-  }
 }

--- a/src/app/assets/containers/asset-detail/asset-detail.component.ts
+++ b/src/app/assets/containers/asset-detail/asset-detail.component.ts
@@ -121,7 +121,9 @@ export class AssetDetailComponent implements OnInit {
 
   isEditingAssetProperty$(): Observable<boolean> {
     return combineLatest([this.asset$, this.assetProperty$]).pipe(
-      map(([aAsset, aAssetProperty]) => aAsset !== undefined && aAssetProperty !== undefined )
+      map(([aAsset, aAssetProperty]) =>
+        aAsset !== undefined && aAssetProperty !== undefined && aAssetProperty.getId() === undefined
+      )
     );
   }
 
@@ -172,6 +174,10 @@ export class AssetDetailComponent implements OnInit {
 
   onPropertySave(aProperty: AssetProperty) {
     this.store.dispatch(new fromStore.CreateProperty(aProperty));
+  }
+
+  onPropertyUpdate(aProperty: AssetProperty) {
+    this.store.dispatch(new fromStore.UpdateProperty(aProperty));
   }
 
   onPropertyEdit(aProperty: AssetProperty) {

--- a/src/app/assets/containers/asset-detail/asset-detail.component.ts
+++ b/src/app/assets/containers/asset-detail/asset-detail.component.ts
@@ -34,13 +34,13 @@ export enum AssetProperties {
   ADRESA = 'adresa',
 }
 
-export enum AssetDetailState {
+export enum FormState {
   View = 'view',
   Edit = 'edit',
 }
 
 interface IPropertyStateMap {
-  [propId: string]: AssetDetailState
+  [propId: string]: FormState
 }
 
 @Component({
@@ -68,7 +68,7 @@ export class AssetDetailComponent implements OnInit {
   measurements: AssetMeasurement[];
   currencies: AssetCurrency[];
 
-  private state: AssetDetailState = AssetDetailState.View;
+  private state: FormState = FormState.View;
   private propertyStates: IPropertyStateMap = {};
 
   properties = [
@@ -97,8 +97,10 @@ export class AssetDetailComponent implements OnInit {
     });
 
     // Initialize each property state in view mode
-    this.defendants$.subscribe(defendants => defendants
-      .forEach(defendant =>  this.propertyStates[defendant.id] = AssetDetailState.View));
+    this.defendants$
+      .pipe(take(1))
+      .subscribe(defendants => defendants
+        .forEach(defendant =>  this.propertyStates[defendant.id] = FormState.View));
 
     this.asset$.pipe(take(1))
       .subscribe((aAsset: Asset) => this.getSubcategories(aAsset.category.id));
@@ -180,13 +182,9 @@ export class AssetDetailComponent implements OnInit {
     this.store.dispatch(new fromStore.UpdateProperty(aProperty));
   }
 
-  onPropertyEdit(aProperty: AssetProperty) {
-
-    if (aProperty.isDefendant()) {
-      this.store.dispatch(new fromStore.UpdateDefendant(aProperty))
-    }
-
-    this.propertyStates[aProperty.getId()] = AssetDetailState.View;
+  onPropertyPersist(aProperty: AssetProperty) {
+    this.store.dispatch(new fromStore.PersistProperty(aProperty));
+    this.propertyStates[aProperty.getId()] = FormState.View;
   }
 
   onEditAsset(aAsset: Asset) {
@@ -207,23 +205,31 @@ export class AssetDetailComponent implements OnInit {
   }
 
   isStateView(): boolean {
-    return this.state === AssetDetailState.View;
+    return this.state === FormState.View;
   }
 
   isStateEdit(): boolean {
-    return this.state === AssetDetailState.Edit;
+    return this.state === FormState.Edit;
   }
 
-  getPropertyState(id: string): AssetDetailState {
-    return this.propertyStates[id] || AssetDetailState.View;
+  getPropertyState(id: string): FormState {
+    return this.propertyStates[id] || FormState.View;
+  }
+
+  isPropertyStateView(id: string): boolean {
+    return this.propertyStates[id] === FormState.View;
+  }
+
+  isPropertyStateEdit(id: string): boolean {
+    return this.propertyStates[id] === FormState.Edit;
   }
 
   setPropertyStateView(id: string): void {
-    this.propertyStates[id] = AssetDetailState.View;
+    this.propertyStates[id] = FormState.View;
   }
 
   setPropertyStateEdit(id: string): void {
-    this.propertyStates[id] = AssetDetailState.Edit;
+    this.propertyStates[id] = FormState.Edit;
   }
 
   private resetSelectedProperty() {
@@ -231,10 +237,10 @@ export class AssetDetailComponent implements OnInit {
   }
 
   private setStateEdit() {
-    this.state = AssetDetailState.Edit;
+    this.state = FormState.Edit;
   }
 
   private setStateView() {
-    this.state = AssetDetailState.View;
+    this.state = FormState.View;
   }
 }

--- a/src/app/assets/containers/asset-detail/asset-detail.component.ts
+++ b/src/app/assets/containers/asset-detail/asset-detail.component.ts
@@ -96,7 +96,7 @@ export class AssetDetailComponent implements OnInit {
       this.addresses$ = this.store.pipe(select(fromStore.getAllAddressesForAssetId(theId)));
     });
 
-    // Initialize each asset property form as view
+    // Initialize each property state in view mode
     this.defendants$.subscribe(defendants => defendants
       .forEach(defendant =>  this.propertyStates[defendant.id] = AssetDetailState.View));
 

--- a/src/app/core/http/defendants-api.service.ts
+++ b/src/app/core/http/defendants-api.service.ts
@@ -31,4 +31,12 @@ export class DefendantsApiService {
         catchError(aError => observableThrowError(aError))
       );
   }
+
+  public updateDefendant(assetId: number, aDefendantRequest: DefendantRequest): Observable<DefendantResponse> {
+    return this.http.put<DefendantResponse>(
+      `${environment.api_url}/assets/${assetId}/defendants/${aDefendantRequest.id}`, aDefendantRequest)
+      .pipe(
+        catchError(aError => observableThrowError(aError))
+      )
+  }
 }

--- a/src/app/core/http/defendants-api.service.ts
+++ b/src/app/core/http/defendants-api.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { throwError as observableThrowError,  Observable } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import { catchError, map } from 'rxjs/operators';
 
 import { environment } from '@env/environment';
 import { DefendantRequest, DefendantResponse } from '../models';
@@ -33,9 +33,16 @@ export class DefendantsApiService {
   }
 
   public updateDefendant(assetId: number, aDefendantRequest: DefendantRequest): Observable<DefendantResponse> {
+
     return this.http.put<DefendantResponse>(
-      `${environment.api_url}/assets/${assetId}/defendants/${aDefendantRequest.id}`, aDefendantRequest)
+      `${environment.api_url}/assets/${assetId}/defendant/${aDefendantRequest.id}`, aDefendantRequest)
       .pipe(
+        map(response => {
+          // FIXME: When doing a `PUT` the API doesn't return the
+          // correct ID of the resource
+          response.id = aDefendantRequest.id;
+          return response
+        }),
         catchError(aError => observableThrowError(aError))
       )
   }

--- a/src/app/core/models/asset/asset-property.model.ts
+++ b/src/app/core/models/asset/asset-property.model.ts
@@ -1,5 +1,7 @@
 import { Asset } from './asset.model';
 
+import { Address, Defendant, Solution, StorageSpace } from './asset-properties';
+
 export enum AssetPropertyType {
   Address = 'Address',
   Defendant = 'Defendant',
@@ -10,6 +12,7 @@ export enum AssetPropertyType {
 export abstract class AssetProperty {
   protected asset: Asset;
   protected assetId: number;
+  protected abstract id: number;
   private _type: AssetPropertyType;
 
   protected constructor(aType: AssetPropertyType) {
@@ -21,6 +24,10 @@ export abstract class AssetProperty {
     this.assetId = aAsset.id;
   }
 
+  getId(): number {
+    return this.id;
+  }
+
   getAsset(): Asset {
     return this.asset;
   }
@@ -29,19 +36,19 @@ export abstract class AssetProperty {
     return this.assetId;
   }
 
-  isAddress(): boolean {
+  isAddress(): this is Address {
     return this.getType() === AssetPropertyType.Address;
   }
 
-  isDefendant(): boolean {
+  isDefendant(): this is Defendant {
     return this.getType() === AssetPropertyType.Defendant;
   }
 
-  isSolution(): boolean {
+  isSolution(): this is Solution {
     return this.getType() === AssetPropertyType.Solution;
   }
 
-  isStorageSpace(): boolean {
+  isStorageSpace(): this is StorageSpace {
     return this.getType() === AssetPropertyType.StorageSpace;
   }
 

--- a/src/app/core/services/defendants.service.ts
+++ b/src/app/core/services/defendants.service.ts
@@ -11,14 +11,18 @@ export class DefendantsService {
   constructor(private defendantsApiService: DefendantsApiService) {
   }
 
+  private handleResponse(response: DefendantResponse, asset: Asset) {
+    const theDefendant = new Defendant(response);
+    theDefendant.setAsset(asset);
+    return theDefendant
+  }
+
   public createDefendant$(aDefendant: Defendant): Observable<Defendant> {
     return this.defendantsApiService.createDefendant$(aDefendant.getAsset().id, this.toRequest(aDefendant))
       .pipe(
-        map((aNewDefendant: DefendantResponse) => {
-          const theDefendant = new Defendant(aNewDefendant);
-          theDefendant.setAsset(aDefendant.getAsset());
-          return theDefendant;
-        })
+        map((aNewDefendant: DefendantResponse) =>
+          this.handleResponse(aNewDefendant, aDefendant.getAsset())
+        )
       );
   }
 
@@ -26,17 +30,24 @@ export class DefendantsService {
     return this.defendantsApiService.getDefendants$(aAsset.id)
       .pipe(
         mergeMap(aDefendants => aDefendants),
-        map((aNewDefendant: DefendantResponse) => {
-          const theDefendant = new Defendant(aNewDefendant);
-          theDefendant.setAsset(aAsset);
-          return theDefendant;
-        }),
+        map((aNewDefendant: DefendantResponse) =>
+          this.handleResponse(aNewDefendant, aAsset)
+        ),
         toArray()
       )
   }
 
   public deleteDefendant$(assetId: number, defendantId: number): Observable<any> {
     return this.defendantsApiService.deleteDefendant(assetId, defendantId);
+  }
+
+  public updateDefendant$(assetId: number, aDefendant: Defendant) {
+    return this.defendantsApiService.updateDefendant(assetId, this.toRequest(aDefendant))
+      .pipe(
+        map((response: DefendantResponse) =>
+          this.handleResponse(response, aDefendant.getAsset())
+        )
+      )
   }
 
   private toRequest(aDefendant: Defendant): DefendantRequest {

--- a/src/app/core/store/actions/asset-properties.action.ts
+++ b/src/app/core/store/actions/asset-properties.action.ts
@@ -5,6 +5,7 @@ export enum AssetPropertyActionTypes {
   CreateProperty = '[Asset Properties] Create Property',
   DeleteProperty = '[Asset Properties] Delete Property',
   UpdateProperty = '[Asset Properties] Update Property',
+  PersistProperty = '[Asset Properties] Persist Property',
 }
 
 // update properties
@@ -23,8 +24,14 @@ export class DeleteProperty implements Action {
   constructor(public payload: number) {}
 }
 
+export class PersistProperty implements Action {
+  readonly type: string = AssetPropertyActionTypes.PersistProperty;
+  constructor(public payload: AssetProperty) {}
+}
+
 // action types
 export type AssetPropertiesAction =
   CreateProperty
   | UpdateProperty
-  | DeleteProperty;
+  | DeleteProperty
+  | PersistProperty;

--- a/src/app/core/store/actions/defendants.action.ts
+++ b/src/app/core/store/actions/defendants.action.ts
@@ -11,6 +11,9 @@ export enum DefendantsActionTypes {
   DeleteDefendant = '[Defendants] Delete Defendant',
   DeleteDefendantFail = '[Defendants] Delete Defendant Fail',
   DeleteDefendantSuccess = '[Defendants] Delete Defendant Success',
+  UpdateDefendant = '[Defendants] Update Defendant',
+  UpdateDefendantFail = '[Defendants] Update Defendant Fail',
+  UpdateDefendantSuccess = '[Defendants] Update Defendant Success',
 }
 
 // create defendant
@@ -60,6 +63,21 @@ export class DeleteDefendantSuccess implements Action {
   constructor(public payload: number) {}
 }
 
+export class UpdateDefendant implements Action {
+  readonly type: string = DefendantsActionTypes.UpdateDefendant;
+  constructor(public payload: Defendant) {}
+}
+
+export class UpdateDefendantFail implements Action {
+  readonly type: string = DefendantsActionTypes.UpdateDefendantFail;
+  constructor(public payload: Defendant) {}
+}
+
+export class UpdateDefendantSuccess implements Action {
+  readonly type: string = DefendantsActionTypes.UpdateDefendantSuccess;
+  constructor(public payload: Defendant) {}
+}
+
 // action types
 export type DefendantsAction =
   CreateDefendant
@@ -70,4 +88,7 @@ export type DefendantsAction =
   | LoadDefendantsSuccess
   | DeleteDefendant
   | DeleteDefendantFail
-  | DeleteDefendantSuccess;
+  | DeleteDefendantSuccess
+  | UpdateDefendant
+  | UpdateDefendantFail
+  | UpdateDefendantSuccess;

--- a/src/app/core/store/effects/asset-properties.effect.ts
+++ b/src/app/core/store/effects/asset-properties.effect.ts
@@ -42,6 +42,24 @@ export class AssetPropertiesEffects {
       })
     );
 
+  @Effect()
+  persistProperty$ = this.actions$
+      .pipe(
+        ofType(assetPropertyActions.AssetPropertyActionTypes.PersistProperty),
+        map(({ payload }: assetPropertyActions.PersistProperty) => {
+
+          if (!payload) {
+            return;
+          }
+
+          if (payload.isDefendant()) {
+            return new defendantActions.UpdateDefendant(payload);
+          }
+
+          return;
+        })
+      )
+
   constructor(private actions$: Actions) {
   }
 }

--- a/src/app/core/store/effects/defendants.effect.ts
+++ b/src/app/core/store/effects/defendants.effect.ts
@@ -65,6 +65,19 @@ export class DefendantsEffects {
       )
     );
 
+  @Effect()
+  updateDefendant$ = this.actions$
+    .pipe(
+      ofType(defendantsActions.DefendantsActionTypes.UpdateDefendant),
+      map((action: defendantsActions.UpdateDefendant) => action.payload),
+      switchMap((aDefendant: Defendant) =>
+        this.defendantsService.updateDefendant$(aDefendant.getAssetId(), aDefendant).pipe(
+          map(defendant => new defendantsActions.UpdateDefendantSuccess(defendant)),
+          catchError(() => of(new defendantsActions.UpdateDefendantFail(aDefendant)))
+        )
+      )
+    )
+
   constructor(
     private actions$: Actions,
     private defendantsService: DefendantsService,

--- a/src/app/core/store/reducers/defendants.reducer.ts
+++ b/src/app/core/store/reducers/defendants.reducer.ts
@@ -62,6 +62,60 @@ export function reducer(
       } as DefendantsState;
     }
 
+    case fromDefendants.DefendantsActionTypes.UpdateDefendant: {
+
+      const defendant = action.payload;
+
+      return {
+        ...state,
+        loading: {
+          ...state.loading,
+          [defendant.id]: true,
+        },
+        loaded: {
+          ...state.loaded,
+          [defendant.id]: false,
+        },
+      }
+    }
+
+    case fromDefendants.DefendantsActionTypes.UpdateDefendantSuccess: {
+
+      const defendant = action.payload;
+
+      return {
+        ...state,
+        entities: {
+          ...state.entities,
+          [defendant.id]: defendant,
+        },
+        loading: {
+          ...state.loading,
+          [defendant.id]: false,
+        },
+        loaded: {
+          ...state.loaded,
+          [defendant.id]: true,
+        },
+      }
+    }
+
+    case fromDefendants.DefendantsActionTypes.UpdateDefendantFail: {
+      const defendant = action.payload;
+
+      return {
+        ...state,
+        loading: {
+          ...state.loading,
+          [defendant.id]: false,
+        },
+        loaded: {
+          ...state.loaded,
+          [defendant.id]: false,
+        },
+      }
+    }
+
     case fromDefendants.DefendantsActionTypes.LoadDefendantsSuccess: {
       const thePayload = (action as fromDefendants.LoadDefendantsSuccess).payload;
       const theAssetId = thePayload.id;

--- a/src/app/core/store/reducers/defendants.reducer.ts
+++ b/src/app/core/store/reducers/defendants.reducer.ts
@@ -87,7 +87,7 @@ export function reducer(
         ...state,
         entities: {
           ...state.entities,
-          [defendant.id]: defendant,
+          [defendant.id]: defendant.toJson(),
         },
         loading: {
           ...state.loading,


### PR DESCRIPTION
### Description of the Change

- Reuse the edit component of the defendants
- Call the `PUT` endpoint with the updated version of a defendant
- Update the store with the updated resource.
- Add some spacing between `Sterge` & `Modifica` buttons

### Notes

- I didn't like the way I had to call the dispatcher in the `onPropertyEdit`, maybe @bogdanconstantinescu can give some input on this one

- I got confused by `inPropertyUpdate` initially because I thought it persists data to the backend, but it just updated the store, that's why I have introduced `onPropertyEdit` to actually persist it. Not a big fan since they have a similar name, again maybe @bogdanconstantinescu can comment on this one :)

- The `PUT` endpoint doesn't return the resource id correctly so I did a temporary fix until the backend is fixed. Should I open a ticket on the API?



